### PR TITLE
Fix dev script commands

### DIFF
--- a/w3o-antelope/package.json
+++ b/w3o-antelope/package.json
@@ -14,7 +14,7 @@
     "copy-version": "node scripts/copy_version.js",
     "build": "npm run copy-version; tsc",
     "test": "jest",
-    "dev": "npm sun clear; pm run copy-version; tsc -w",
+    "dev": "npm run clear && npm run copy-version && tsc -w",
     "publish-on": "npm run build && npm publish --access public",
     "src": "node scripts/concatenate_src.js"
   },

--- a/w3o-core/package.json
+++ b/w3o-core/package.json
@@ -14,7 +14,7 @@
     "copy-version": "node scripts/copy_version.js",
     "build": "npm run copy-version; tsc",
     "test": "jest",
-    "dev": "npm sun clear; pm run copy-version; tsc -w",
+    "dev": "npm run clear && npm run copy-version && tsc -w",
     "publish-on": "npm run build && npm publish --access public",
     "src": "node scripts/concatenate_src.js"
   },


### PR DESCRIPTION
## Summary
- fix typos in dev scripts for w3o-core and w3o-antelope

## Testing
- `npm test` in `w3o-core` *(fails: jest not found)*
- `npm test` in `w3o-antelope` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c65c28db083208c5a928b55cc236e