### PR TITLE
Fix README session option example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const services = [
 ];
 octopus.registerServices(services);
 octopus.init({
-    multisession: true, // if false, W3oSessionManager we maitain always one open session and logout the user if the network changes
+    multiSession: true, // if false, W3oSessionManager will maintain only one open session and logout the user if the network changes
 });
 
 export function getOctopus(): Web3Octopus<IMyServices> {
@@ -127,7 +127,7 @@ export function getOctopus(): Web3Octopus<IMyServices> {
 }
 ```
 
-Luego desde cualquier otro lado del proyecto podemos hacer lo sigueinte
+Luego desde cualquier otro lado del proyecto podemos hacer lo siguiente
 
 ```typescript
 // ejemplo de uso desde otro archivo


### PR DESCRIPTION
## Summary
- use `multiSession` option in README example
- fix typos: maintain, siguiente

## Testing
- `npm test --silent` (fails: jest not found)
- `(cd w3o-core && npm test --silent)` (fails: jest not found)
- `(cd w3o-antelope && npm test --silent)` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_684c65e2e4b08320b4f4e59fab44112f