### PR TITLE
Add ethereum support

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -41,6 +41,6 @@
     "@angular/compiler-cli": "^19.1.3",
     "@angular-devkit/build-angular": "^19.2.3",
     "@types/node": "^18.0.0",
-    "typescript": "~5.5.0"
+    "typescript": "5.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
     "serve": "npm --prefix example run start",
     "build:core": "npm --prefix w3o-core run build",
     "build:antelope": "npm --prefix w3o-antelope run build",
+    "build:ethereum": "npm --prefix w3o-ethereum run build",
     "build:example": "npm --prefix example run build",
-    "build": "npm run build:core && npm run build:antelope",
+    "build": "npm run build:core && npm run build:antelope && npm run build:ethereum && npm run build:example",
     "install:core": "npm --prefix w3o-core install",
     "install:antelope": "npm --prefix w3o-antelope install",
+    "install:ethereum": "npm --prefix w3o-ethereum install",
     "install:example": "npm --prefix example install",
-    "postinstall": "npm run install:core && npm run install:antelope && npm run install:example",
+    "postinstall": "npm run install:core && npm run install:antelope && npm run install:ethereum && npm run install:example",
     "clear": "rm -fr w3o-core/lib w3o-antelope/lib example/node_modules w3o-core/node_modules w3o-antelope/node_modules ./node_modules example/.angular"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./w3o-core" },
-    { "path": "./w3o-antelope" }
+    { "path": "./w3o-antelope" },
+    { "path": "./w3o-ethereum" }
   ]
 }

--- a/w3o-antelope/package.json
+++ b/w3o-antelope/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "@types/bn.js": "^4.11.0",
     "@types/ws": "^8.18.1",
-    "typescript": "^4.9.5"
+    "typescript": "5.3.3"
   }
 }

--- a/w3o-core/package.json
+++ b/w3o-core/package.json
@@ -15,6 +15,6 @@
     "rxjs": ">=6.0.0"
   },
   "devDependencies": {
-    "typescript": "^4.9.5"
+    "typescript": "5.3.3"
   }
 }

--- a/w3o-ethereum/package.json
+++ b/w3o-ethereum/package.json
@@ -21,18 +21,18 @@
   "dependencies": {
     "@vapaee/w3o-core": "file:../w3o-core",
     "ethers": "^6.10.0",
-    "wagmi": "^1.6.3",
+    "wagmi": "2.15.6",
     "rxjs": ">=6.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.3.3"
+    "typescript": "5.3.3"
   },
   "peerDependencies": {
     "ethers": "^6.0.0",
-    "wagmi": "^1.6.0",
+    "wagmi": "2.15.6",
     "rxjs": ">=6.0.0"
   }
 }

--- a/w3o-ethereum/tsconfig.json
+++ b/w3o-ethereum/tsconfig.json
@@ -14,9 +14,9 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "skipLibCheck": true,
-        "declaration": true
+        "declaration": true,
+        "lib": ["esnext"]
     },
-    "lib": ["esnext"],
     "include": [
         "src/**/*.ts"
     ],


### PR DESCRIPTION
## Summary
- add build & install scripts for Ethereum
- reference Ethereum in root tsconfig
- align Typescript version to 5.3.3 across packages
- upgrade `wagmi` to `2.15.6`
- move `lib` to compiler options in Ethereum tsconfig

## Testing
- `npm run build` *(fails: Cannot find module 'rxjs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684cdf0267c483209c4a5b7957103d03