### PR TITLE
Add post method to HTTP client

### DIFF
--- a/w3o-core/src/classes/W3oDefaultHttpClient.ts
+++ b/w3o-core/src/classes/W3oDefaultHttpClient.ts
@@ -29,4 +29,30 @@ export class W3oDefaultHttpClient implements W3oHttpClient {
                 });
         });
     }
+
+    /**
+     * Performs a POST request with a JSON body and returns an observable with the response JSON
+     */
+    post<T>(url: string, body: unknown): Observable<T> {
+        return new Observable<T>(subscriber => {
+            fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            })
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    subscriber.next(data as T);
+                    subscriber.complete();
+                })
+                .catch(error => {
+                    subscriber.error(error);
+                });
+        });
+    }
 }

--- a/w3o-core/src/types/w3o-interfaces.ts
+++ b/w3o-core/src/types/w3o-interfaces.ts
@@ -21,6 +21,7 @@ import {
  */
 export interface W3oHttpClient {
     get<T>(url: string): Observable<T>;
+    post<T>(url: string, body: unknown): Observable<T>;
 }
 
 /**

--- a/w3o-ethereum/src/classes/EthereumNetwork.ts
+++ b/w3o-ethereum/src/classes/EthereumNetwork.ts
@@ -7,7 +7,7 @@ import {
     W3oNetwork,
     W3oToken,
     W3oModule,
-    W3oHttpClient,
+    W3oDefaultHttpClient,
 } from '@vapaee/w3o-core';
 import { Observable } from 'rxjs';
 import { ethers } from 'ethers';
@@ -26,19 +26,7 @@ export class EthereumNetwork extends W3oNetwork {
     constructor(settings: W3oEthereumNetworkSettings, parent: W3oContext) {
         const context = logger.method('constructor', { chain: settings.displayName, settings }, parent);
         if (!settings.httpClient) {
-            settings.httpClient = {
-                get: <T>(url: string): Observable<T> => {
-                    return new Observable<T>(subscriber => {
-                        fetch(url, { method: 'GET' })
-                            .then(res => {
-                                if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
-                                return res.json();
-                            })
-                            .then(data => { subscriber.next(data as T); subscriber.complete(); })
-                            .catch(err => subscriber.error(err));
-                    });
-                }
-            } as W3oHttpClient;
+            settings.httpClient = new W3oDefaultHttpClient();
         }
         super(settings, context);
         this._settings = settings;


### PR DESCRIPTION
## Summary
- expand `W3oHttpClient` interface with `post`
- implement post request in `W3oDefaultHttpClient`
- support post method in `EthereumNetwork` fallback HTTP client
- switch `EthereumNetwork` to use `W3oDefaultHttpClient`

## Testing
- `npm --prefix w3o-core run build` *(fails: Cannot find module 'rxjs')*

------
https://chatgpt.com/codex/tasks/task_e_68506b48ddcc83208009201cf2651924