### PR TITLE
Add Telos EVM Mainnet network

### DIFF
--- a/example/src/app/services/web3-octopus.service.ts
+++ b/example/src/app/services/web3-octopus.service.ts
@@ -20,6 +20,11 @@ import {
     TelosZeroNetwork,
     TelosZeroTestnetNetwork,
 } from '@vapaee/w3o-antelope';
+// import the classes to support Ethereum networks
+import {
+    EthereumAuthMetamask,
+    TelosEVMNetwork,
+} from '@vapaee/w3o-ethereum';
 
 import { VortDEXw3oServices } from '@app/types';
 
@@ -57,6 +62,16 @@ export class Web3OctopusService implements OnDestroy {
                 ]
             }
             this.octopus.addNetworkSupport(telosSupportSettings, context);
+
+            // ---- Register Telos EVM support ----
+            const telosEvmSupportSettings: W3oNetworkSupportSettings = {
+                type: 'ethereum',
+                chain: new EthereumAuthMetamask(context),
+                networks: [
+                    new TelosEVMNetwork({}, context),
+                ]
+            }
+            this.octopus.addNetworkSupport(telosEvmSupportSettings, context);
 
             // ---- Register the services ----
             // paths must match the keys in the IMyServices interface

--- a/w3o-ethereum/src/classes/EthereumChains.ts
+++ b/w3o-ethereum/src/classes/EthereumChains.ts
@@ -71,9 +71,12 @@ const TelosEVMConfigJSON: W3oEthereumNetworkSettings = {
     type,
     name: 'telos-evm' as W3oNetworkName,
     chainId: '40',
-    displayName: 'Telos EVM',
+    displayName: 'Telos EVM Mainnet',
     rpcUrl: 'https://mainnet.telos.net/evm',
     tokensUrl: 'assets/tokens-ethereum-telos-evm.json',
+    symbol: 'TLOS',
+    nativeCurrency: 'Telos',
+    decimals: 18,
     links: {
         explorer: 'https://teloscan.io',
         bridge: '',
@@ -102,6 +105,9 @@ const TelosEVMTestnetConfigJSON: W3oEthereumNetworkSettings = {
     displayName: 'Telos EVM Testnet',
     rpcUrl: 'https://testnet.telos.net/evm',
     tokensUrl: 'assets/tokens-ethereum-telos-evm-testnet.json',
+    symbol: 'TLOS',
+    nativeCurrency: 'Telos',
+    decimals: 18,
     links: {
         explorer: 'https://testnet.teloscan.io',
         bridge: '',


### PR DESCRIPTION
## Summary
- configure Telos EVM network with chainId 40 and TLOS details
- expose Telos EVM network in example service using Metamask auth

## Testing
- `npm run build` *(fails: Cannot find module 'rxjs' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68507bf62480832095922974ce7acfa7