### PR TITLE
Add Antelope resources section with service updates

### DIFF
--- a/example/public/assets/locals/en.json
+++ b/example/public/assets/locals/en.json
@@ -27,6 +27,12 @@
             "DESCRIPTION": "Your token balance",
             "LOADING": "Loading..."
         },
+        "RESOURCES": {
+            "NAME": "Resources",
+            "TITLE": "Resources",
+            "DESCRIPTION": "Account CPU, NET and RAM usage",
+            "NOT_APPLICABLE": "Not applicable"
+        },
         "PREFERENCES": {
             "NAME": "Preferences",
             "TITLE": "User Preferences",

--- a/example/public/assets/locals/es.json
+++ b/example/public/assets/locals/es.json
@@ -27,6 +27,12 @@
             "DESCRIPTION": "Balance de tus tokens",
             "LOADING": "Cargando..."
         },
+        "RESOURCES": {
+            "NAME": "Recursos",
+            "TITLE": "Recursos",
+            "DESCRIPTION": "Uso de CPU, NET y RAM de la cuenta",
+            "NOT_APPLICABLE": "No aplica"
+        },
         "PREFERENCES": {
             "NAME": "Preferencias",
             "TITLE": "Preferencias de Usuario",

--- a/example/src/app/app.routes.ts
+++ b/example/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { PoolComponent } from '@app/pages/pool/pool.component';
 import { WalletComponent } from './pages/wallet/wallet.component';
 import { PreferencesComponent } from './pages/preferences/preferences.component';
 import { AccountsComponent } from './pages/accounts/accounts.component';
+import { ResourcesComponent } from './pages/resources/resources.component';
 
 export const routes: Routes = [
     // Navigate to 'home' component by default (empty path)
@@ -15,6 +16,7 @@ export const routes: Routes = [
     { path: 'explore', component: ExploreComponent },
     { path: 'pool', component: PoolComponent },
     { path: 'wallet', component: WalletComponent },
+    { path: 'resources', component: ResourcesComponent },
     { path: 'preferences', component: PreferencesComponent},
     { path: 'accounts', component: AccountsComponent},
 ];

--- a/example/src/app/components/login/login.component.html
+++ b/example/src/app/components/login/login.component.html
@@ -16,6 +16,7 @@
             <!-- Dropdown Body -->
             <div dropdown-body class="c-login__menu-body">
                 <a class="c-login__menu-option" routerLink="/wallet">{{'PAGES.WALLET.NAME' | translate}}</a>
+                <a *ngIf="isAntelope" class="c-login__menu-option" routerLink="/resources">{{'PAGES.RESOURCES.NAME' | translate}}</a>
                 <a class="c-login__menu-option" routerLink="/accounts">{{'PAGES.ACCOUNTS.NAME' | translate}}</a>
                 <a class="c-login__menu-option" routerLink="/preferences">{{'PAGES.PREFERENCES.NAME' | translate}}</a>
                 <hr class="c-login__menu-separator">

--- a/example/src/app/components/login/login.component.ts
+++ b/example/src/app/components/login/login.component.ts
@@ -6,6 +6,7 @@ import { SessionService } from '@app/services/session-kit.service';
 import { LucideAngularModule, User } from 'lucide-angular';
 import { ExpandableManagerService } from '../base-components/expandable/expandable-manager.service';
 import { SharedModule } from '@app/shared/shared.module';
+import { Web3OctopusService } from '@app/services/web3-octopus.service';
 
 @Component({
     selector: 'app-login',
@@ -26,7 +27,12 @@ export class LoginComponent {
     constructor(
         public sessionService: SessionService,
         public expandibles: ExpandableManagerService,
+        private w3o: Web3OctopusService,
     ) {}
+
+    get isAntelope(): boolean {
+        return this.w3o.octopus.networks.current.type === 'antelope';
+    }
 
     async login() {
         try {

--- a/example/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/example/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -23,6 +23,10 @@
         <lucide-icon [img]="WalletIcon"></lucide-icon>
         <p>{{'PAGES.WALLET.NAME' | translate}}</p>
     </a>
+    <a *ngIf="isAntelope" class="c-side-menu__option" routerLink="/resources" routerLinkActive="active-link">
+        <lucide-icon [img]="WalletIcon"></lucide-icon>
+        <p>{{'PAGES.RESOURCES.NAME' | translate}}</p>
+    </a>
 
     <a class="c-side-menu__option" routerLink="/preferences" routerLinkActive="active-link">
         <lucide-icon [img]="SettingsIcon"></lucide-icon>

--- a/example/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
+++ b/example/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
@@ -13,6 +13,7 @@ import {
 import { RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
 import { SharedModule } from '@app/shared/shared.module';
+import { Web3OctopusService } from '@app/services/web3-octopus.service';
 
 @Component({
     selector: 'app-side-menu-mobile',
@@ -44,8 +45,13 @@ export class SideMenuMobileComponent {
     // }
 
     constructor(
-        public sessionService: SessionService
+        public sessionService: SessionService,
+        private w3o: Web3OctopusService
     ) {}
+
+    get isAntelope(): boolean {
+        return this.w3o.octopus.networks.current.type === 'antelope';
+    }
 
     get isLogged(): boolean {
         return !!this.sessionService.current;

--- a/example/src/app/pages/resources/resources.component.html
+++ b/example/src/app/pages/resources/resources.component.html
@@ -1,0 +1,43 @@
+<div class="p-resources" *ngIf="isAntelope; else na">
+    <div class="p-resources__container" [class.mobile]="isMobileView" *ngIf="state as s">
+        <div class="p-resources__card">
+            <p class="p-resources__title">CPU</p>
+            <div class="p-resources__bar">
+                <div class="p-resources__bar-fill" [style.width.%]="s.resources.cpu.percent"></div>
+            </div>
+            <p class="p-resources__text">{{s.resources.cpu.available}} / {{s.resources.cpu.total}}</p>
+            <div class="p-resources__actions">
+                <button class="p-resources__btn" (click)="stakeCpu()">Stake</button>
+                <button class="p-resources__btn" (click)="unstakeCpu()">Unstake</button>
+                <lucide-icon [img]="RefreshIcon" (click)="refresh()" class="p-resources__refresh"></lucide-icon>
+            </div>
+        </div>
+        <div class="p-resources__card">
+            <p class="p-resources__title">NET</p>
+            <div class="p-resources__bar">
+                <div class="p-resources__bar-fill" [style.width.%]="s.resources.net.percent"></div>
+            </div>
+            <p class="p-resources__text">{{s.resources.net.available}} / {{s.resources.net.total}}</p>
+            <div class="p-resources__actions">
+                <button class="p-resources__btn" (click)="stakeNet()">Stake</button>
+                <button class="p-resources__btn" (click)="unstakeNet()">Unstake</button>
+                <lucide-icon [img]="RefreshIcon" (click)="refresh()" class="p-resources__refresh"></lucide-icon>
+            </div>
+        </div>
+        <div class="p-resources__card">
+            <p class="p-resources__title">RAM</p>
+            <div class="p-resources__bar">
+                <div class="p-resources__bar-fill" [style.width.%]="s.resources.ram.percent"></div>
+            </div>
+            <p class="p-resources__text">{{s.resources.ram.available}} / {{s.resources.ram.total}}</p>
+            <div class="p-resources__actions">
+                <button class="p-resources__btn" (click)="buyRam()">Buy</button>
+                <button class="p-resources__btn" (click)="sellRam()">Sell</button>
+                <lucide-icon [img]="RefreshIcon" (click)="refresh()" class="p-resources__refresh"></lucide-icon>
+            </div>
+        </div>
+    </div>
+</div>
+<ng-template #na>
+    <div class="p-resources__na">{{ 'PAGES.RESOURCES.NOT_APPLICABLE' | translate }}</div>
+</ng-template>

--- a/example/src/app/pages/resources/resources.component.scss
+++ b/example/src/app/pages/resources/resources.component.scss
@@ -1,0 +1,62 @@
+@use 'mixin' as *;
+
+:host {
+    @include page;
+}
+
+.p-resources {
+    width: 100%;
+    max-width: 770px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+
+    &__container {
+        display: flex;
+        gap: 20px;
+
+        &.mobile {
+            flex-direction: column;
+        }
+    }
+
+    &__card {
+        @include container-border;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 10px;
+    }
+
+    &__title {
+        @include text-subtitle;
+    }
+
+    &__bar {
+        @include progress-bar();
+    }
+
+    &__text {
+        @include text-smaller;
+    }
+
+    &__actions {
+        display: flex;
+        gap: 10px;
+    }
+
+    &__btn {
+        @include button-1;
+        padding: 5px 10px;
+        font-size: 12px;
+    }
+
+    &__refresh {
+        cursor: pointer;
+    }
+
+    &__na {
+        @include text-subtitle;
+    }
+}

--- a/example/src/app/pages/resources/resources.component.ts
+++ b/example/src/app/pages/resources/resources.component.ts
@@ -1,0 +1,86 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ResourcesService } from '@app/services/resources.service';
+import { AntelopeResourcesState } from '@app/types';
+import { Subject, takeUntil } from 'rxjs';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { Web3OctopusService } from '@app/services/web3-octopus.service';
+import { LucideAngularModule, RefreshCcw } from 'lucide-angular';
+import { SharedModule } from '@app/shared/shared.module';
+import { BREAKPOINT } from '@app/types';
+
+@Component({
+    selector: 'app-resources',
+    standalone: true,
+    imports: [CommonModule, SharedModule, LucideAngularModule],
+    templateUrl: './resources.component.html',
+    styleUrls: ['./resources.component.scss']
+})
+export class ResourcesComponent implements OnInit, OnDestroy {
+    readonly RefreshIcon = RefreshCcw;
+
+    state: AntelopeResourcesState | null = null;
+    isMobileView = false;
+    isAntelope = false;
+
+    private destroy$ = new Subject<void>();
+
+    constructor(
+        private resourcesService: ResourcesService,
+        private breakpointObserver: BreakpointObserver,
+        private w3o: Web3OctopusService,
+    ) {}
+
+    ngOnInit() {
+        this.breakpointObserver.observe(BREAKPOINT)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(result => this.isMobileView = result.matches);
+
+        this.resourcesService.getResources$()
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(state => this.state = state);
+
+        this.w3o.octopus.networks.current$
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(net => this.isAntelope = net.type === 'antelope');
+    }
+
+    ngOnDestroy() {
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+
+    refresh() {
+        this.resourcesService.refresh();
+    }
+
+    stakeCpu() {
+        const amount = parseFloat(prompt('CPU amount') || '0');
+        if (amount > 0) this.resourcesService.stakeCpu(amount).subscribe();
+    }
+
+    unstakeCpu() {
+        const amount = parseFloat(prompt('CPU amount') || '0');
+        if (amount > 0) this.resourcesService.unstakeCpu(amount).subscribe();
+    }
+
+    stakeNet() {
+        const amount = parseFloat(prompt('NET amount') || '0');
+        if (amount > 0) this.resourcesService.stakeNet(amount).subscribe();
+    }
+
+    unstakeNet() {
+        const amount = parseFloat(prompt('NET amount') || '0');
+        if (amount > 0) this.resourcesService.unstakeNet(amount).subscribe();
+    }
+
+    buyRam() {
+        const bytes = parseInt(prompt('RAM bytes') || '0', 10);
+        if (bytes > 0) this.resourcesService.buyRam(bytes).subscribe();
+    }
+
+    sellRam() {
+        const bytes = parseInt(prompt('RAM bytes') || '0', 10);
+        if (bytes > 0) this.resourcesService.sellRam(bytes).subscribe();
+    }
+}

--- a/example/src/app/services/resources.service.ts
+++ b/example/src/app/services/resources.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { Web3OctopusService } from './web3-octopus.service';
+import { SessionService } from './session-kit.service';
+import { AntelopeResourcesState } from '@vapaee/w3o-antelope';
+import { W3oContextFactory } from '@vapaee/w3o-core';
+
+const logger = new W3oContextFactory('ResourcesService');
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ResourcesService {
+    private state$ = new BehaviorSubject<AntelopeResourcesState | null>(null);
+    private sub?: Subscription;
+
+    constructor(
+        private w3o: Web3OctopusService,
+        private sessionService: SessionService
+    ) {
+        this.sessionService.session$.subscribe(session => {
+            const context = logger.method('sessionChange');
+            this.sub?.unsubscribe();
+            const network = this.w3o.octopus.networks.current;
+            if (session?.authenticator && network.type === 'antelope') {
+                this.sub = this.w3o.octopus.services.resources
+                    .getResources$(session.authenticator, context)
+                    .subscribe(state => this.state$.next(state));
+            } else {
+                this.state$.next(null);
+            }
+        });
+    }
+
+    getResources$() {
+        return this.state$.asObservable();
+    }
+
+    refresh() {
+        const context = logger.method('refresh');
+        const auth = this.sessionService.current?.authenticator;
+        if (auth && this.w3o.octopus.networks.current.type === 'antelope') {
+            this.w3o.octopus.services.resources.updateResources(auth, context);
+        }
+    }
+
+    stakeCpu(amount: number) { return this.w3o.octopus.services.resources.stakeCpu(amount); }
+    unstakeCpu(amount: number) { return this.w3o.octopus.services.resources.unstakeCpu(amount); }
+    stakeNet(amount: number) { return this.w3o.octopus.services.resources.stakeNet(amount); }
+    unstakeNet(amount: number) { return this.w3o.octopus.services.resources.unstakeNet(amount); }
+    buyRam(bytes: number) { return this.w3o.octopus.services.resources.buyRam(bytes); }
+    sellRam(bytes: number) { return this.w3o.octopus.services.resources.sellRam(bytes); }
+}

--- a/example/src/app/style/_mixin.scss
+++ b/example/src/app/style/_mixin.scss
@@ -156,3 +156,17 @@
     background-color: var(--c-background-1);
     padding: 20px 30px;
 }
+
+@mixin progress-bar($height: 8px) {
+    width: 100%;
+    height: $height;
+    background-color: var(--c-background-3);
+    border-radius: 4px;
+    overflow: hidden;
+
+    &-fill {
+        height: 100%;
+        background: var(--c-gradient-0);
+        width: 0%;
+    }
+}

--- a/example/src/app/types/Resources.ts
+++ b/example/src/app/types/Resources.ts
@@ -1,1 +1,5 @@
-export type { AntelopeResources as Resources } from '@vapaee/w3o-antelope';
+export type {
+    AntelopeResourcesState as ResourcesState,
+    AntelopeBalanceBreakdown,
+    AntelopeResources
+} from '@vapaee/w3o-antelope';

--- a/w3o-antelope/src/types/w3o-interfaces.ts
+++ b/w3o-antelope/src/types/w3o-interfaces.ts
@@ -49,7 +49,7 @@ export interface AntelopeTransaction extends W3oTransaction {
 /**
  * Aggregated resources information for an Antelope account
  */
-export interface AntelopeResources {
+export interface AntelopeBalanceBreakdown {
     total: string;              // Total TLOS owned by the user
     liquid: string;             // Liquid TLOS available for transfers
     rexStaked: string;          // Amount of TLOS in REX including savings
@@ -170,4 +170,52 @@ export interface AntelopeAccountData {
     rex_info?: AntelopeRexInfo;
     subjective_cpu_bill_limit: AntelopeResourceLimit;
     eosio_any_linked_actions: unknown[];
+}
+
+/** Row of the `rexbal` table */
+export interface AntelopeRexbalRow {
+    version: number;
+    owner: string;
+    vote_stake: string;
+    rex_balance: string;
+    matured_rex: string;
+    rex_maturities: AntelopeRexMaturity[];
+}
+
+/** Query result for the `rexbal` table */
+export interface AntelopeRexbalTable {
+    rows: AntelopeRexbalRow[];
+}
+
+/** Row of the `rexfund` table */
+export interface AntelopeRexfundRow {
+    owner: string;
+    balance: string;
+}
+
+/** Query result for the `rexfund` table */
+export interface AntelopeRexfundTable {
+    rows: AntelopeRexfundRow[];
+}
+
+/** Detailed resource usage information */
+export interface AntelopeResource {
+    total: number;
+    used: number;
+    percent: number;
+    available: number;
+}
+
+/** CPU/NET/RAM resources information */
+export interface AntelopeResources {
+    cpu: AntelopeResource;
+    net: AntelopeResource;
+    ram: AntelopeResource;
+}
+
+/** Complete resources state object */
+export interface AntelopeResourcesState {
+    balance: AntelopeBalanceBreakdown;
+    resources: AntelopeResources;
+    account: AntelopeAccountData | null;
 }


### PR DESCRIPTION
## Summary
- add Resources page showing CPU, NET and RAM usage
- add new Angular service to provide resource state and actions
- expose menu links only when connected to Antelope networks
- update translations for the Resources section
- overhaul Antelope resource types and service to provide detailed state
- include progress-bar mixin for styling

## Testing
- `npx tsc -p w3o-antelope/tsconfig.json` *(fails: Cannot find module '@vapaee/w3o-core')*

------
https://chatgpt.com/codex/tasks/task_e_6850c261910c8320b30d4f4d89a87235