### PR TITLE
Fix login button width with truncated address

### DIFF
--- a/example/src/app/components/login/login.component.html
+++ b/example/src/app/components/login/login.component.html
@@ -10,7 +10,7 @@
             <!-- Dropdown Button -->
             <button dropdown-button class="c-login__btn--active">
                 <lucide-icon [img]="UserIcon" size="18"></lucide-icon>
-                {{ session.address }}
+                {{ shorten(session.address) }}
             </button>
 
             <!-- Dropdown Body -->

--- a/example/src/app/components/login/login.component.ts
+++ b/example/src/app/components/login/login.component.ts
@@ -43,4 +43,8 @@ export class LoginComponent {
         await this.sessionService.logout();
         this.expandibles.closeAll();
     }
+
+    shorten(address: string): string {
+        return address.length > 13 ? `${address.slice(0, 6)}...${address.slice(-4)}` : address;
+    }
 }


### PR DESCRIPTION
## Summary
- shorten the displayed address on the login dropdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850d4218c108320a99b250a2a44d0bf