### PR TITLE
Update transfer service and login menu

### DIFF
--- a/example/src/app/components/login/login.component.html
+++ b/example/src/app/components/login/login.component.html
@@ -15,12 +15,12 @@
 
             <!-- Dropdown Body -->
             <div dropdown-body class="c-login__menu-body">
-                <a class="c-login__menu-option" routerLink="/wallet">{{'PAGES.WALLET.NAME' | translate}}</a>
-                <a *ngIf="isAntelope" class="c-login__menu-option" routerLink="/resources">{{'PAGES.RESOURCES.NAME' | translate}}</a>
-                <a class="c-login__menu-option" routerLink="/accounts">{{'PAGES.ACCOUNTS.NAME' | translate}}</a>
-                <a class="c-login__menu-option" routerLink="/preferences">{{'PAGES.PREFERENCES.NAME' | translate}}</a>
+                <a class="c-login__menu-option" *ngFor="let s of sessions" (click)="selectSession(s)">
+                    <img class="c-login__menu-network-icon" [src]="'/assets/logos/' + (s.network.name.replace('-testnet','')) + '.png'"/>
+                    {{ shorten(s.address) }}
+                </a>
                 <hr class="c-login__menu-separator">
-                <a class="c-login__menu-option" (click)="logout()">{{'TYPES.BUTTON.LOGOUT' | translate}}</a>
+                <a class="c-login__menu-option" routerLink="/accounts">{{'PAGES.ACCOUNTS.NAME' | translate}}</a>
             </div>
         </app-drop-down>
     </div>

--- a/example/src/app/components/login/login.component.scss
+++ b/example/src/app/components/login/login.component.scss
@@ -21,6 +21,12 @@
         &-option {
             @include hyperlink;
         }
+        &-network-icon {
+            width: 16px;
+            height: 16px;
+            margin-right: 6px;
+            border-radius: 50%;
+        }
         &-separator {
             @include hr-separator(0px);
         }

--- a/example/src/app/components/login/login.component.ts
+++ b/example/src/app/components/login/login.component.ts
@@ -4,9 +4,9 @@ import { DropDownComponent } from '@app/components/base-components/drop-down/dro
 import { Router, RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
 import { LucideAngularModule, User } from 'lucide-angular';
-import { ExpandableManagerService } from '../base-components/expandable/expandable-manager.service';
 import { SharedModule } from '@app/shared/shared.module';
 import { Web3OctopusService } from '@app/services/web3-octopus.service';
+import { W3oSession, W3oContextFactory } from '@vapaee/w3o-core';
 
 @Component({
     selector: 'app-login',
@@ -23,25 +23,25 @@ import { Web3OctopusService } from '@app/services/web3-octopus.service';
 })
 export class LoginComponent {
     readonly UserIcon = User
+    private logger = new W3oContextFactory('LoginComponent');
 
     constructor(
         public sessionService: SessionService,
-        public expandibles: ExpandableManagerService,
         private w3o: Web3OctopusService,
         private router: Router,
     ) {}
-
-    get isAntelope(): boolean {
-        return this.w3o.octopus.networks.current.type === 'antelope';
-    }
 
     async login() {
         await this.router.navigate(['/accounts']);
     }
 
-    async logout() {
-        await this.sessionService.logout();
-        this.expandibles.closeAll();
+    get sessions(): W3oSession[] {
+        return this.w3o.octopus.sessions.list;
+    }
+
+    selectSession(session: W3oSession) {
+        const context = this.logger.method('selectSession');
+        this.w3o.octopus.sessions.setCurrentSession(session.id, context);
     }
 
     shorten(address: string): string {

--- a/example/src/app/components/token-transfer-form/token-transfer-form.component.html
+++ b/example/src/app/components/token-transfer-form/token-transfer-form.component.html
@@ -65,7 +65,7 @@
             <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.TO' | translate }}</strong> {{ transferStatus.summary.to }}</p>
             <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.AMOUNT' | translate }}</strong> {{ transferStatus.summary.amount }}</p>
             <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.TRANSACTION' | translate }}</strong>
-                <a [href]="'https://explorer.telos.net/transaction/' + transferStatus.summary.transaction" target="_blank">
+                <a [href]="tokenTransferService.getExplorerTxUrl(transferStatus.summary.transaction)" target="_blank">
                     {{ transferStatus.summary.transaction.substring(0, 10) }} <!-- ✅ Shorten only in UI -->
                 </a>
             </p>

--- a/example/src/app/services/token-transfer.service.ts
+++ b/example/src/app/services/token-transfer.service.ts
@@ -1,14 +1,16 @@
 // src/app/services/token-transfer.service.ts
 
-import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
 import {
     W3oContextFactory,
     W3oTransferStatus,
     W3oToken,
+    W3oNetworkType,
 } from '@vapaee/w3o-core';
 import { Web3OctopusService } from './web3-octopus.service';
-import { SessionService } from './session-kit.service';
+import { AntelopeTokensService } from '@vapaee/w3o-antelope';
+import { EthereumTokensService } from '@vapaee/w3o-ethereum';
 
 const logger = new W3oContextFactory('TokenTransferService');
 
@@ -22,13 +24,27 @@ export class TokenTransferService {
 
     }
 
+    private getServiceFor(type: W3oNetworkType): AntelopeTokensService | EthereumTokensService {
+        console.assert(!!this.w3o.octopus.services[type], `No service registered for network type: ${type}`);
+        return this.w3o.octopus.services[type].tokens;
+    }
+
     /**
      * Returns an observable of transfer status for the given token symbol
      * @param tokenSymbol The symbol of the token to track
      */
     public getTransferStatus$(tokenSymbol: string): Observable<W3oTransferStatus> {
         const context = logger.method('getTransferStatus$', { tokenSymbol });
-        return this.w3o.octopus.services.antelope.tokens.getTransferStatus(tokenSymbol, context);
+        const session = this.w3o.octopus.sessions.current;
+        if (!session) {
+            context.error('No active session');
+            return of({ state: 'none' } as W3oTransferStatus);
+        }
+        const svc = this.getServiceFor(session.network.type);
+        if (svc instanceof AntelopeTokensService) {
+            return svc.getTransferStatus(tokenSymbol, context);
+        }
+        return of({ state: 'none' } as W3oTransferStatus);
     }
 
     /**
@@ -42,7 +58,10 @@ export class TokenTransferService {
             context.error('No active session');
             return;
         }
-        this.w3o.octopus.services.antelope.tokens.resetTransferCycle(auth, tokenSymbol, context);
+        const svc = this.getServiceFor(auth.network.type);
+        if (svc instanceof AntelopeTokensService) {
+            svc.resetTransferCycle(auth, tokenSymbol, context);
+        }
     }
 
     /**
@@ -55,7 +74,10 @@ export class TokenTransferService {
             context.error('No active session');
             return;
         }
-        this.w3o.octopus.services.antelope.tokens.resetAllTransfers(auth, context);
+        const svc = this.getServiceFor(auth.network.type);
+        if (svc instanceof AntelopeTokensService) {
+            svc.resetAllTransfers(auth, context);
+        }
     }
 
     /**
@@ -77,6 +99,17 @@ export class TokenTransferService {
             context.error('No active session');
             return;
         }
-        await this.w3o.octopus.services.antelope.tokens.transferToken(auth, to, quantity, token, memo, context);
+        const svc = this.getServiceFor(auth.network.type);
+        await svc.transferToken(auth, to, quantity, token, memo, context);
+    }
+
+    public getExplorerTxUrl(tx: string): string {
+        const network = this.w3o.octopus.networks.current;
+        const base = network.settings.links.explorer;
+        if (!base) return '';
+        if (network.type === 'ethereum') {
+            return `${base}/tx/${tx}`;
+        }
+        return `${base}/transaction/${tx}`;
     }
 }


### PR DESCRIPTION
## Summary
- refactor token transfer service for multi-network support
- update transfer form to use dynamic explorer URL
- show session list in login dropdown for quick switching
- style login dropdown network icons

## Testing
- `npm run build:core` *(fails: Cannot find module 'rxjs' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3e4722c8320b58dc3e8ee95de55