### PR TITLE
Add GitHub Pages build for example

### DIFF
--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -1,0 +1,40 @@
+name: Build and Deploy Example
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: example/docs
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "ng serve",
-    "build": "ng build"
+    "build": "ng build --configuration production --output-path docs --base-href ./"
   },
   "_": {
     "@vapaee/w3o-antelope": "file:../w3o-antelope/src",

--- a/example/src/app/app.config.ts
+++ b/example/src/app/app.config.ts
@@ -1,6 +1,6 @@
 // src/app/app.config.ts
 import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withHashLocation } from '@angular/router';
 import { withInterceptorsFromDi, provideHttpClient, HttpClient } from '@angular/common/http';
 import { routes } from './app.routes';
 import { StoreModule } from '@ngrx/store';
@@ -18,7 +18,7 @@ export function httpLoaderFactory(http: HttpClient) {
 export const appConfig: ApplicationConfig = {
     providers: [
         provideZoneChangeDetection({ eventCoalescing: true }),
-        provideRouter(routes),
+        provideRouter(routes, withHashLocation()),
         provideHttpClient(withInterceptorsFromDi()),
         importProvidersFrom(
             StoreModule.forRoot(

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:antelope": "npm --prefix w3o-antelope run build",
     "build:ethereum": "npm --prefix w3o-ethereum run build",
     "build:example": "npm --prefix example run build",
-    "build": "npm run build:core && npm run install:antelope && npm run build:antelope && npm run install:ethereum && npm run build:ethereum",
+    "build": "npm run build:core && npm run install:antelope && npm run build:antelope && npm run install:ethereum && npm run build:ethereum && npm run build:example",
     "install:core": "npm --prefix w3o-core install",
     "install:antelope": "npm --prefix w3o-antelope install",
     "install:ethereum": "npm --prefix w3o-ethereum install",


### PR DESCRIPTION
## Summary
- enable hash-based routing in example app
- output built demo to `docs` directory
- include example build in root build script
- configure GitHub Actions workflow to deploy demo to GitHub Pages

## Testing
- `npm run build` *(fails: Cannot find module 'rxjs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6851a79e05e4832087c33fa62d0cd5d2