### PR TITLE
Fix ethereum token transfer signer

### DIFF
--- a/w3o-ethereum/src/classes/EthereumTokensService.ts
+++ b/w3o-ethereum/src/classes/EthereumTokensService.ts
@@ -137,11 +137,11 @@ export class EthereumTokensService extends W3oService {
         void memo;
         const result$ = new Subject<W3oTransferSummary>();
         try {
-            const network = (auth.account as W3oAccount).authenticator.network as unknown as EthereumNetwork;
-            const signer = new ethers.Wallet(auth.session.storage.get('privateKey') as string, network.provider);
+            const network = auth.network as unknown as EthereumNetwork;
+            const signer = network.provider.getSigner();
             const contract = new ethers.Contract(token.address, erc20Abi, signer);
             contract.transfer(to, quantity).then((tx: any) => {
-                result$.next({ from: signer.address, to, amount: quantity, transaction: tx.hash });
+                result$.next({ from: auth.session.address, to, amount: quantity, transaction: tx.hash });
                 result$.complete();
             }).catch((error: any) => {
                 context.error('transfer error', error);


### PR DESCRIPTION
## Summary
- remove private key signer
- use network provider signer for transfers

## Testing
- `npm run build` *(fails: Cannot find module 'rxjs')*

------
https://chatgpt.com/codex/tasks/task_e_6851b59db188832088384d7ab797fdec