### PR TITLE
Suppress Angular commonjs warnings

### DIFF
--- a/example/angular.json
+++ b/example/angular.json
@@ -39,7 +39,18 @@
                             "includePaths": [
                                 "src/app/style"
                             ]
-                        }
+                        },
+                        "allowedCommonJsDependencies": [
+                            "brorand",
+                            "hash.js",
+                            "bn.js",
+                            "elliptic",
+                            "eventemitter3",
+                            "js-sha3",
+                            "bech32",
+                            "aes-js",
+                            "scrypt-js"
+                        ]
                     },
                     "configurations": {
                         "production": {


### PR DESCRIPTION
## Summary
- configure Angular build to allow known CommonJS dependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851d289307c83208cee89240749d1f0