### PR TITLE
Parse quantity for ERC20 transfers

### DIFF
--- a/w3o-ethereum/src/classes/EthereumTokensService.ts
+++ b/w3o-ethereum/src/classes/EthereumTokensService.ts
@@ -140,7 +140,11 @@ export class EthereumTokensService extends W3oService {
             const network = auth.network as unknown as EthereumNetwork;
             const signer = network.provider.getSigner();
             const contract = new ethers.Contract(token.address, erc20Abi, signer);
-            contract.transfer(to, quantity).then((tx: any) => {
+
+            const numericPart = quantity.split(' ')[0];
+            const amount = ethers.utils.parseUnits(numericPart, token.precision);
+
+            contract.transfer(to, amount).then((tx: any) => {
                 result$.next({ from: auth.session.address, to, amount: quantity, transaction: tx.hash });
                 result$.complete();
             }).catch((error: any) => {


### PR DESCRIPTION
## Summary
- handle numeric+symbol quantity format in `EthereumTokensService.transferToken`
- keep example token transfer form building formatted amounts with the symbol

## Testing
- `npm run build:ethereum` *(fails: Cannot find module '@vapaee/w3o-core' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851d775e8bc8320b5abb54cf28876d2