### PR TITLE
Improve dev home page layout

### DIFF
--- a/dev/src/app/pages/home/home.component.scss
+++ b/dev/src/app/pages/home/home.component.scss
@@ -5,11 +5,51 @@
 }
 
 .p-home {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    &__header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    &__logo {
+        width: 150px;
+        height: auto;
+    }
     &__title {
         @include text-title;
     }
     &__subtitle {
         @include text-subtitle;
+    }
+    &__packages {
+        margin: 1.5rem 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.3rem;
+    }
+    &__package {
+        @include hyperlink;
+    }
+    &__install {
+        @include container-border;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-family: monospace;
+    }
+    &__code {
+        white-space: nowrap;
+    }
+    &__copy {
+        background: none;
+        border: none;
+        cursor: pointer;
+        color: var(--c-foreground-0);
     }
     &__link {
         margin-top: 3rem;

--- a/dev/src/app/pages/home/home.component.ts
+++ b/dev/src/app/pages/home/home.component.ts
@@ -1,7 +1,7 @@
 // src/app/pages/home/home.component.ts
 import { Component } from '@angular/core';
 import { SharedModule } from '@app/shared/shared.module';
-import { LucideAngularModule, Github } from 'lucide-angular';
+import { LucideAngularModule, Github, Copy } from 'lucide-angular';
 
 @Component({
     standalone: true,
@@ -9,8 +9,25 @@ import { LucideAngularModule, Github } from 'lucide-angular';
     imports: [SharedModule, LucideAngularModule],
     template: `
         <div class="p-home">
-            <div class="p-home__title">{{ 'PAGES.HOME.TITLE' | translate }}</div>
+            <div class="p-home__header">
+                <img class="p-home__logo" src="/assets/octopus.png" alt="octopus" />
+                <div class="p-home__title">{{ 'PAGES.HOME.TITLE' | translate }}</div>
+            </div>
             <p class="p-home__subtitle">{{ 'PAGES.HOME.DESCRIPTION' | translate }}</p>
+
+            <div class="p-home__packages">
+                <a class="p-home__package" href="https://www.npmjs.com/package/@vapaee/w3o-core" target="_blank">&#64;vapaee/web3-core&#64;1.0.1</a>
+                <a class="p-home__package" href="https://www.npmjs.com/package/@vapaee/w3o-antelope" target="_blank">&#64;vapaee/web3-antelope&#64;1.0.1</a>
+                <a class="p-home__package" href="https://www.npmjs.com/package/@vapaee/w3o-ethereum" target="_blank">&#64;vapaee/web3-ethereum&#64;1.0.0</a>
+            </div>
+
+            <div class="p-home__install">
+                <code class="p-home__code">npm i &#64;vapaee/web3-core &#64;vapaee/web3-antelope &#64;vapaee/web3-ethereum</code>
+                <button class="p-home__copy" (click)="copyInstall()">
+                    <lucide-icon [img]="CopyIcon" size="16"></lucide-icon>
+                </button>
+            </div>
+
             <a class="p-home__link" href="https://github.com/vapaee/web3-octopus" target="_blank">
                 <lucide-icon [img]="GithubIcon" size="16"></lucide-icon>
                 {{ 'PAGES.HOME.SOURCE' | translate }}
@@ -21,4 +38,10 @@ import { LucideAngularModule, Github } from 'lucide-angular';
 })
 export class HomeComponent {
     readonly GithubIcon = Github;
+    readonly CopyIcon = Copy;
+
+    copyInstall() {
+        const cmd = 'npm i @vapaee/web3-core @vapaee/web3-antelope @vapaee/web3-ethereum';
+        navigator.clipboard.writeText(cmd);
+    }
 }


### PR DESCRIPTION
## Summary
- spruce up the dev home page with centered logo and title
- list framework packages with links
- add install command with copy button

## Testing
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_685460f3a0988320852d0c9b1b62553e