### PR TITLE
Implement EVM transfer status updates

### DIFF
--- a/dev/src/app/services/token-transfer.service.ts
+++ b/dev/src/app/services/token-transfer.service.ts
@@ -41,7 +41,7 @@ export class TokenTransferService {
             return of({ state: 'none' } as W3oTransferStatus);
         }
         const svc = this.getServiceFor(session.network.type);
-        if (svc instanceof AntelopeTokensService) {
+        if (svc instanceof AntelopeTokensService || svc instanceof EthereumTokensService) {
             return svc.getTransferStatus(tokenSymbol, context);
         }
         return of({ state: 'none' } as W3oTransferStatus);
@@ -59,7 +59,7 @@ export class TokenTransferService {
             return;
         }
         const svc = this.getServiceFor(auth.network.type);
-        if (svc instanceof AntelopeTokensService) {
+        if (svc instanceof AntelopeTokensService || svc instanceof EthereumTokensService) {
             svc.resetTransferCycle(auth, tokenSymbol, context);
         }
     }
@@ -75,13 +75,13 @@ export class TokenTransferService {
             return;
         }
         const svc = this.getServiceFor(auth.network.type);
-        if (svc instanceof AntelopeTokensService) {
+        if (svc instanceof AntelopeTokensService || svc instanceof EthereumTokensService) {
             svc.resetAllTransfers(auth, context);
         }
     }
 
     /**
-     * Transfers tokens using the AntelopeTokensService
+     * Transfers tokens using the underlying network service
      * @param to Recipient account
      * @param quantity Quantity string (e.g. '1.0000 TLOS')
      * @param token W3oToken object


### PR DESCRIPTION
## Summary
- extend EthereumTokensService with transfer status observables
- update transferToken to emit success/failure and refresh balances
- expose new status API in dev TokenTransferService so the UI can track Ethereum transfers

## Testing
- `npm run build:core`
- `npm run build:antelope`
- `npm run build:ethereum`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_68546b30fa988320ba0d12af99883e55