### PR TITLE
Apply hyperlink style to summary links

### DIFF
--- a/dev/src/app/components/token-transfer-form/token-transfer-form.component.html
+++ b/dev/src/app/components/token-transfer-form/token-transfer-form.component.html
@@ -65,7 +65,7 @@
             <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.TO' | translate }}</strong> {{ transferStatus.summary.to }}</p>
             <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.AMOUNT' | translate }}</strong> {{ transferStatus.summary.amount }}</p>
             <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.TRANSACTION' | translate }}</strong>
-                <a [href]="tokenTransferService.getExplorerTxUrl(transferStatus.summary.transaction)" target="_blank">
+                <a class="c-token-transfer__tx-link" [href]="tokenTransferService.getExplorerTxUrl(transferStatus.summary.transaction)" target="_blank">
                     {{ transferStatus.summary.transaction.substring(0, 10) }} <!-- ✅ Shorten only in UI -->
                 </a>
             </p>

--- a/dev/src/app/components/token-transfer-form/token-transfer-form.component.scss
+++ b/dev/src/app/components/token-transfer-form/token-transfer-form.component.scss
@@ -90,4 +90,8 @@
             color: var(--c-alert-0);
         }
     }
+
+    &__tx-link {
+        @include hyperlink;
+    }
 }

--- a/dev/src/app/pages/home/home.component.scss
+++ b/dev/src/app/pages/home/home.component.scss
@@ -52,6 +52,7 @@
         color: var(--c-foreground-0);
     }
     &__link {
+        @include hyperlink;
         margin-top: 3rem;
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Summary
- style the tx link in token transfer summary
- use the hyperlink mixin for p-home links

## Testing
- `npm --prefix dev run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_685479eccb708320ac80c314f5b3f4cf