### PR TITLE
Add missing SUCCSES translations

### DIFF
--- a/dev/public/assets/locals/en.json
+++ b/dev/public/assets/locals/en.json
@@ -75,6 +75,7 @@
                 }
             },
             "SUCCESS": "✅ Transaction Successful",
+            "SUCCSES": "✅ Transaction Successful",
             "FAILURE": "❌ Transaction Failed"
         }
     },

--- a/dev/public/assets/locals/es.json
+++ b/dev/public/assets/locals/es.json
@@ -75,6 +75,7 @@
                 }
             },
             "SUCCESS": "✅ Transacción Exitosa",
+            "SUCCSES": "✅ Transacción Exitosa",
             "FAILURE": "❌ Transacción Fallida"
         }
     },


### PR DESCRIPTION
## Summary
- add Spanish and English strings for `COMPONENTS.TRANSFER-FORM.SUCCSES`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68549ebd43008320a976534e1561a91e