### PR TITLE
Implement common W3oTokensService interface

### DIFF
--- a/w3o-antelope/src/classes/AntelopeTokensService.ts
+++ b/w3o-antelope/src/classes/AntelopeTokensService.ts
@@ -15,14 +15,14 @@ import {
 } from "@vapaee/w3o-core";
 import { BehaviorSubject, combineLatest, Observable, of, Subject, throwError } from "rxjs";
 import { map, catchError } from "rxjs/operators";
-import { AntelopeTransferSummary } from "../types";
+import { AntelopeTransferSummary, W3oTokensService } from "../types";
 
 const logger = new W3oContextFactory('AntelopeTokensService');
 
 /**
  * Service responsible for managing token balances and transfers on Antelope networks.
  */
-export class AntelopeTokensService extends W3oService {
+export class AntelopeTokensService extends W3oService implements W3oTokensService {
 
     constructor(path: string, parent: W3oContext) {
         const context = logger.method('constructor', { path }, parent);

--- a/w3o-antelope/src/types/w3o-interfaces.ts
+++ b/w3o-antelope/src/types/w3o-interfaces.ts
@@ -5,7 +5,12 @@ import {
     W3oTransaction,
     W3oTransferStatus,
     W3oTransferSummary,
+    W3oAuthenticator,
+    W3oContext,
+    W3oBalance,
+    W3oToken,
 } from "@vapaee/w3o-core";
+import { BehaviorSubject, Observable } from "rxjs";
 import { ActionType, AnyAction, AnyTransaction } from "@wharfkit/antelope";
 import { ChainDefinition } from "@wharfkit/common";
 import { SigningRequest } from "@wharfkit/session";
@@ -218,4 +223,32 @@ export interface AntelopeResourcesState {
     balance: AntelopeBalanceBreakdown;
     resources: AntelopeResources;
     account: AntelopeAccountData | null;
+}
+
+/**
+ * Common interface that any token service implementation must follow.
+ */
+export interface W3oTokensService {
+    getBalances$(auth: W3oAuthenticator, parent: W3oContext): BehaviorSubject<W3oBalance[]>;
+    updateAllBalances(auth: W3oAuthenticator, parent: W3oContext): void;
+    waitUntilBalanceChanges(
+        auth: W3oAuthenticator,
+        token: W3oToken,
+        delay: number,
+        maxSeconds: number,
+        parent: W3oContext
+    ): Observable<W3oBalance>;
+    getTransferStatus$(auth: W3oAuthenticator, parent: W3oContext): BehaviorSubject<Map<string, W3oTransferStatus>>;
+    getTransferStatusForAuth(auth: W3oAuthenticator, tokenSymbol: string, parent: W3oContext): Observable<W3oTransferStatus>;
+    getTransferStatus(tokenSymbol: string, parent: W3oContext): Observable<W3oTransferStatus>;
+    resetTransferCycle(auth: W3oAuthenticator, tokenSymbol: string, parent: W3oContext): void;
+    resetAllTransfers(auth: W3oAuthenticator, parent: W3oContext): void;
+    transferToken(
+        auth: W3oAuthenticator,
+        to: string,
+        quantity: string,
+        token: W3oToken,
+        memo: string,
+        parent: W3oContext
+    ): Observable<W3oTransferSummary>;
 }

--- a/w3o-ethereum/package.json
+++ b/w3o-ethereum/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@vapaee/w3o-core": "file:../w3o-core/lib",
+    "@vapaee/w3o-antelope": "file:../w3o-antelope/lib",
     "ethers": "^5.5.1",
     "rxjs": ">=6.0.0"
   },

--- a/w3o-ethereum/src/classes/EthereumTokensService.ts
+++ b/w3o-ethereum/src/classes/EthereumTokensService.ts
@@ -17,6 +17,7 @@ import { BehaviorSubject, combineLatest, Observable, of, Subject } from "rxjs";
 import { map } from "rxjs/operators";
 import { ethers } from "ethers";
 import { EthereumNetwork } from "./EthereumNetwork";
+import { W3oTokensService } from "@vapaee/w3o-antelope";
 
 const logger = new W3oContextFactory('EthereumTokensService');
 const erc20Abi = [
@@ -24,7 +25,7 @@ const erc20Abi = [
     "function transfer(address to, uint amount) returns (bool)"
 ];
 
-export class EthereumTokensService extends W3oService {
+export class EthereumTokensService extends W3oService implements W3oTokensService {
     constructor(path: string, parent: W3oContext) {
         const context = logger.method('constructor', { path }, parent);
         super(path, context);


### PR DESCRIPTION
## Summary
- define `W3oTokensService` interface for token services
- implement the interface in Ethereum and Antelope token service classes
- expose the new type in Antelope package
- add Antelope package as dependency for Ethereum package

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68549f55eff08320b46840ff614f1296