### PR TITLE
Update build-dev workflow triggers

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,9 +1,10 @@
 name: Build and Deploy Dev
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+    types: [closed]
 
 permissions:
   contents: read
@@ -16,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -39,6 +41,7 @@ jobs:
           path: dev/dist/browser
 
   deploy:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- only run build-dev workflow when PRs merge to `main`
- keep manual workflow dispatch trigger

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854b8ec717c8320bda9ae3cf173b74c