### PR TITLE
Fix default dark theme initialization

### DIFF
--- a/dev/src/app/services/local-storage.service.ts
+++ b/dev/src/app/services/local-storage.service.ts
@@ -51,8 +51,13 @@ export class LocalStorageService {
                 this.store.dispatch(user.actions.setLight());
             }
             if (typeof preferences.h0 === 'number' && typeof preferences.h1 === 'number') {
-                this.store.dispatch(user.actions.setHueTheme({ h0: preferences.h0, h1: preferences.h1 }));
+                this.store.dispatch(
+                    user.actions.setHueTheme({ h0: preferences.h0, h1: preferences.h1 })
+                );
             }
+        } else {
+            // If no preferences exist, apply dark theme by default
+            this.store.dispatch(user.actions.setDark());
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure dark theme is set when no user preferences exist

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854c37dda34832082825792a47a3ccc