### PR TITLE
Support string-based ABI fragments

### DIFF
--- a/w3o-ethereum/src/types/w3o-abi.ts
+++ b/w3o-ethereum/src/types/w3o-abi.ts
@@ -65,4 +65,4 @@ export type EthereumAbiItem =
     | EthereumFallbackAbiItem
     | EthereumReceiveAbiItem;
 
-export type EthereumContractAbi = readonly EthereumAbiItem[];
+export type EthereumContractAbi = readonly (EthereumAbiItem | string)[];


### PR DESCRIPTION
## Summary
- allow `EthereumContractAbi` to include string-based ABI fragments
- parse function fragments defined as strings when resolving contract calls

## Testing
- npm run build *(fails: missing local @vapaee/w3o-core types in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f503ab9a6083209940ddf06009d27b